### PR TITLE
NC26 requires this changes

### DIFF
--- a/lib/Middleware/AEAuthMiddleware.php
+++ b/lib/Middleware/AEAuthMiddleware.php
@@ -68,7 +68,7 @@ class AEAuthMiddleware extends Middleware {
 		$this->logger = $logger;
 	}
 
-	public function beforeController(Controller $controller, string $methodName) {
+	public function beforeController($controller, $methodName) {
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 
 		$isAEAuth = $this->hasAnnotationOrAttribute($reflectionMethod, 'AEAuth', AppEcosystemAuth::class);


### PR DESCRIPTION
`Declaration of OCA\AppEcosystemV2\Middleware\AEAuthMiddleware::beforeController(OCP\AppFramework\Controller $controller, string $methodName) must be compatible with OCP\AppFramework\Middleware::beforeController($controller, $methodName) at /var/www/html/apps/app_ecosystem_v2/lib/Middleware/AEAuthMiddleware.php#71`