### PR TITLE
config command fixes, remove deprecated annotation reflector

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,9 +1,6 @@
 name: Docs check
 on:
   pull_request:
-    paths:
-      - '.github/workflows/docs-check.yml'
-      - 'docs/**'
 
 permissions:
   contents: read

--- a/lib/Db/ExAppConfigMapper.php
+++ b/lib/Db/ExAppConfigMapper.php
@@ -74,21 +74,6 @@ class ExAppConfigMapper extends QBMapper {
 	/**
 	 * @throws Exception
 	 */
-	public function updateAppConfigValue(ExAppConfig $appConfigEx): int {
-		$qb = $this->db->getQueryBuilder();
-		return $qb->update($this->tableName)
-			->set('configvalue', $qb->createNamedParameter($appConfigEx->getConfigvalue(), IQueryBuilder::PARAM_STR))
-			->set('sensitive', $qb->createNamedParameter($appConfigEx->getSensitive(), IQueryBuilder::PARAM_INT))
-			->where(
-				$qb->expr()->eq('appid', $qb->createNamedParameter($appConfigEx->getAppid(), IQueryBuilder::PARAM_STR)),
-				$qb->expr()->eq('configkey', $qb->createNamedParameter($appConfigEx->getConfigkey(), IQueryBuilder::PARAM_STR))
-			)
-		->executeStatement();
-	}
-
-	/**
-	 * @throws Exception
-	 */
 	public function deleteByAppidConfigkeys(string $appId, array $configKeys): int {
 		$qb = $this->db->getQueryBuilder();
 		return $qb->delete($this->tableName)

--- a/lib/Middleware/AppEcosystemAuthMiddleware.php
+++ b/lib/Middleware/AppEcosystemAuthMiddleware.php
@@ -13,27 +13,23 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
-use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 use ReflectionMethod;
 
 class AppEcosystemAuthMiddleware extends Middleware {
-	private IControllerMethodReflector $reflector;
 	private AppEcosystemV2Service $service;
 	protected IRequest $request;
 	private IL10N $l;
 	private LoggerInterface $logger;
 
 	public function __construct(
-		IControllerMethodReflector $reflector,
-		AppEcosystemV2Service $service,
+	AppEcosystemV2Service $service,
 		IRequest $request,
 		IL10N $l,
 		LoggerInterface $logger,
 	) {
-		$this->reflector = $reflector;
 		$this->service = $service;
 		$this->request = $request;
 		$this->l = $l;
@@ -43,33 +39,13 @@ class AppEcosystemAuthMiddleware extends Middleware {
 	public function beforeController($controller, $methodName) {
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 
-		$isAppEcosystemAuth = $this->hasAnnotationOrAttribute($reflectionMethod, 'AppEcosystemAuth', AppEcosystemAuth::class);
+		$isAppEcosystemAuth = !empty($reflectionMethod->getAttributes(AppEcosystemAuth::class));
 
 		if ($isAppEcosystemAuth) {
 			if (!$this->service->validateExAppRequestToNC($this->request)) {
 				throw new AEAuthNotValidException($this->l->t('AppEcosystemV2 authentication failed'), Http::STATUS_UNAUTHORIZED);
 			}
 		}
-	}
-
-	/**
-	 * @template T
-	 *
-	 * @param ReflectionMethod $reflectionMethod
-	 * @param string $annotationName
-	 * @param class-string<T> $attributeClass
-	 * @return boolean
-	 */
-	protected function hasAnnotationOrAttribute(ReflectionMethod $reflectionMethod, string $annotationName, string $attributeClass): bool {
-		if (!empty($reflectionMethod->getAttributes($attributeClass))) {
-			return true;
-		}
-
-		if ($this->reflector->hasAnnotation($annotationName)) {
-			return true;
-		}
-
-		return false;
 	}
 
 	/**

--- a/lib/Middleware/AppEcosystemAuthMiddleware.php
+++ b/lib/Middleware/AppEcosystemAuthMiddleware.php
@@ -25,7 +25,7 @@ class AppEcosystemAuthMiddleware extends Middleware {
 	private LoggerInterface $logger;
 
 	public function __construct(
-	AppEcosystemV2Service $service,
+		AppEcosystemV2Service $service,
 		IRequest $request,
 		IL10N $l,
 		LoggerInterface $logger,

--- a/lib/Service/ExAppConfigService.php
+++ b/lib/Service/ExAppConfigService.php
@@ -54,11 +54,11 @@ class ExAppConfigService {
 	 * @param string $appId
 	 * @param string $configKey
 	 * @param mixed $configValue
-	 * @param int $sensitive
+	 * @param int|null $sensitive
 	 *
 	 * @return ExAppConfig|null
 	 */
-	public function setAppConfigValue(string $appId, string $configKey, mixed $configValue, int $sensitive = 0): ?ExAppConfig {
+	public function setAppConfigValue(string $appId, string $configKey, mixed $configValue, ?int $sensitive = null): ?ExAppConfig {
 		$appConfigEx = $this->getAppConfig($appId, $configKey);
 		if ($appConfigEx === null) {
 			try {
@@ -66,7 +66,7 @@ class ExAppConfigService {
 					'appid' => $appId,
 					'configkey' => $configKey,
 					'configvalue' => $configValue ?? '',
-					'sensitive' => $sensitive,
+					'sensitive' => $sensitive ?? 0,
 				]));
 			} catch (Exception $e) {
 				$this->logger->error(sprintf('Failed to insert appconfig_ex value. Error: %s', $e->getMessage()), ['exception' => $e]);
@@ -74,8 +74,10 @@ class ExAppConfigService {
 			}
 		} else {
 			$appConfigEx->setConfigvalue($configValue);
-			$appConfigEx->setSensitive($sensitive);
-			if ($this->updateAppConfigValue($appConfigEx) !== 1) {
+			if ($sensitive !== null) {
+				$appConfigEx->setSensitive($sensitive);
+			}
+			if ($this->updateAppConfigValue($appConfigEx) === null) {
 				$this->logger->error(sprintf('Error while updating appconfig_ex %s value.', $configKey));
 				return null;
 			}
@@ -129,11 +131,11 @@ class ExAppConfigService {
 	/**
 	 * @param ExAppConfig $exAppConfig
 	 *
-	 * @return int|null
+	 * @return ExAppConfig|null
 	 */
-	public function updateAppConfigValue(ExAppConfig $exAppConfig): ?int {
+	public function updateAppConfigValue(ExAppConfig $exAppConfig): ?ExAppConfig {
 		try {
-			return $this->mapper->updateAppConfigValue($exAppConfig);
+			return $this->mapper->update($exAppConfig);
 		} catch (Exception) {
 			return null;
 		}


### PR DESCRIPTION
Resolves: #21

Changes:

- [x] do not update sensitive flag each time config value updated
- [x] remove deprecated and unused `IControllerMethodReflector` in `AppEcosystemAuthMiddleware`