### PR TITLE
`/apps/files/ajax/` to `DAV` scope

### DIFF
--- a/lib/Service/ExAppApiScopeService.php
+++ b/lib/Service/ExAppApiScopeService.php
@@ -95,6 +95,7 @@ class ExAppApiScopeService {
 			['api_route' => '/apps/weather_status/api/', 'scope_group' => 13, 'name' => 'WEATHER_STATUS'],
 			['api_route' => '/apps/files_sharing/api/', 'scope_group' => 14, 'name' => 'FILES_SHARING'],
 			['api_route' => '/dav/', 'scope_group' => 3, 'name' => 'DAV'],
+			['api_route' => '/apps/files/ajax/', 'scope_group' => 3, 'name' => 'DAV'],
 		];
 
 		$this->cache->clear('/all_api_scopes');


### PR DESCRIPTION
added `/apps/files/ajax/` to `DAV` scope

Full route looks something like this: `/index.php/apps/files/ajax/download.php?dir=/Media`

This is not DAV, in the near future we need to separate scopes, as Calendar and other stuff uses DAV too, so `DAV` should be `FileSystem` or something like this.

Rebase on top of #40 to make CI pass.